### PR TITLE
Redis dependency added

### DIFF
--- a/xo_install.sh
+++ b/xo_install.sh
@@ -22,7 +22,7 @@ xo_service="xo-server.service"
 
 # Ensures that Yarn dependencies are installed
 /usr/bin/apt-get update
-/usr/bin/apt-get --yes install git curl apt-transport-https gnupg
+/usr/bin/apt-get --yes install git curl apt-transport-https gnupg redis
 
 #Install yarn
 cd /opt


### PR DESCRIPTION
Redis server must be available on the same machine and must listen on port 6379 otherwise the xo-server.service cannot start.
When xo-server.service is not starting,due to the missing redis server, the error is:
```
ERROR unhandled error event {
error: Error: Redis connection to 127.0.0.1:6379 failed - connect ECONNREFUSED 127.0.0.1:6379
at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1141:16) {
errno: 'ECONNREFUSED',
code: 'ECONNREFUSED',
syscall: 'connect',
address: '127.0.0.1',
port: 6379
 }
}
```